### PR TITLE
Task-01/ Replace CSolid with vector of IPrim

### DIFF
--- a/modules/core/CompositeGeometry.cpp
+++ b/modules/core/CompositeGeometry.cpp
@@ -9,8 +9,8 @@ namespace rt {
 	// Constructor
 	CCompositeGeometry::CCompositeGeometry(const CSolid &s1, const CSolid &s2, BoolOp operationType)
 		: IPrim(nullptr)
-		, m_s1(s1)
-		, m_s2(s2)
+		, m_vpPrims1(s1.getPrims())
+		, m_vpPrims2(s2.getPrims())
 		, m_origin(0.5f * (s1.getPivot() + s2.getPivot()))
 		, m_operationType(operationType)
 	{
@@ -49,16 +49,15 @@ namespace rt {
 	}
 
 	bool CCompositeGeometry::intersect(Ray &ray) const {
-		
+
 		std::pair<Ray, Ray> range1(ray, ray);
 		std::pair<Ray, Ray> range2(ray, ray);
 		range1.second.t = -Infty;
 		range2.second.t = -Infty;
 		bool hasIntersection = false;
-		for (const auto &prim : m_s1.getPrims()) {
+		for (auto &prim : m_vpPrims1) {
 			Ray r = ray;
-			double t = ray.t;
-			if (prim->intersect(r)) {
+            if (prim->intersect(r)) {
 				if (r.t < range1.first.t)
 					range1.first = r;
 				if (r.t > range1.second.t)
@@ -66,7 +65,7 @@ namespace rt {
 				hasIntersection = true;
 			}
 		}
-		for (const auto &prim : m_s2.getPrims()) {
+		for (auto &prim : m_vpPrims2) {
 			Ray r = ray;
 			if (prim->intersect(r)) {
 				if (r.t < range2.first.t)

--- a/modules/core/CompositeGeometry.h
+++ b/modules/core/CompositeGeometry.h
@@ -28,8 +28,8 @@ namespace rt {
 		
 		
     private:
-        CSolid 			m_s1;				///<
-        CSolid 			m_s2;				///<
+        std::vector<ptr_prim_t>	m_vpPrims1;
+        std::vector<ptr_prim_t>	m_vpPrims2;
 		Vec3f			m_origin;
 		BoolOp			m_operationType;	///<
         CBoundingBox 	m_boundingBox;		///<


### PR DESCRIPTION
@ereator I'm not sure if we should change the constructor to only take a vector of primitives or if we should keep a `CSolid`. Imo, I think the `CSolid` looks more intuitive but it might be misleading somehow. 