### PR TITLE
CSG Check Bound Intersection in NO BSP Mode

### DIFF
--- a/modules/core/CompositeGeometry.cpp
+++ b/modules/core/CompositeGeometry.cpp
@@ -48,8 +48,8 @@ namespace rt {
         m_boundingBox = CBoundingBox(minPt, maxPt);
         m_origin = m_boundingBox.getCenter();
 #ifdef ENABLE_BSP
-        m_pBSPTree1->build(m_vPrims1, maxPrimitives, maxDepth);
-        m_pBSPTree2->build(m_vPrims2, maxPrimitives, maxDepth);
+        m_pBSPTree1->build(m_vPrims1, maxDepth, maxPrimitives);
+        m_pBSPTree2->build(m_vPrims2, maxDepth, maxPrimitives);
 #endif
     }
 
@@ -75,6 +75,12 @@ namespace rt {
             }
         }
 #else
+        // check if the ray intersects the bounding box
+        double t0 = 0;
+        double t1 = ray.t;
+        m_boundingBox.clip(ray, t0, t1);
+        if (t1 < t0)
+            return false;
         for (const auto &prim : m_vPrims1) {
             Ray r = ray;
             if (prim->intersect(r)) {

--- a/modules/core/CompositeGeometry.h
+++ b/modules/core/CompositeGeometry.h
@@ -23,7 +23,7 @@ namespace rt {
          * @todo does it makes sense to construct the trees on object construction?
 		 */
         DllExport explicit CCompositeGeometry(const CSolid &s1, const CSolid &s2, BoolOp operationType,
-                                              int maxDepth = 3, int maxPrimitives = 20);
+                                              int maxDepth = 20, int maxPrimitives = 3);
 
         DllExport virtual ~CCompositeGeometry(void) = default;
 

--- a/modules/core/CompositeGeometry.h
+++ b/modules/core/CompositeGeometry.h
@@ -42,6 +42,8 @@ namespace rt {
         DllExport virtual CBoundingBox getBoundingBox(void) const override { return m_boundingBox; }
 
     private:
+        DllExport void computeBoundingBox();
+
         std::vector<ptr_prim_t> m_vPrims1;                ///< Vector of primitives of the first geometry.
         std::vector<ptr_prim_t> m_vPrims2;                ///< Vector of primitives of the second geometry.
         Vec3f m_origin;           ///< Origin/Pivot of the geometry.


### PR DESCRIPTION
Since we already store the definition of the bounding box then we could also do a ray-box check before we start iterating over the primitives inside the composite in no BSP mode. Of course, if BSP mode is enabled then the same check is done on the root node level. Also fixed an issue with swapped parameters in the tree definitions.

This increases the time tremendously if the composite doesn't take up the whole scene. However, if it does then this becomes similar to the naive procedure. Additionally, this means we need to recompute the bounding box after transforming because otherwise, the old bounding would no longer conform to the old solids.