### PR TITLE
[WIP] Openrt 35/ refactor flip normal logic

### DIFF
--- a/demos/Demo CSG.cpp
+++ b/demos/Demo CSG.cpp
@@ -54,8 +54,9 @@ std::shared_ptr<CScene> buildSceneEarth(const Vec3f& bgColor, const Size resolut
 	ptr_prim_t composite1   = std::make_shared<CCompositeGeometry>(earth, box, BoolOp::Difference);
 	ptr_prim_t composite2   = std::make_shared<CCompositeGeometry>(composite1, core, BoolOp::Union);
 
-	pScene->add(earth);
+	//pScene->add(earth);
 	//pScene->add(core);
+    pScene->add(composite1);
 
 	// Light
 	auto sun            = std::make_shared<CLightOmni>(Vec3f::all(1e9), Vec3f(23500, 0, 0), true);

--- a/modules/core/CompositeGeometry.h
+++ b/modules/core/CompositeGeometry.h
@@ -30,11 +30,11 @@ namespace rt {
         DllExport explicit CCompositeGeometry(const CSolid& s1, const CSolid& s2, BoolOp operationType, int maxDepth = 3, int maxPrimitives = 20);
         DllExport virtual ~CCompositeGeometry(void) override = default;
         
-		DllExport virtual bool			intersect(Ray &ray) const override;
+		DllExport virtual bool			intersect(Ray &ray) override;
         DllExport virtual bool			if_intersect(const Ray &ray) const override;
         DllExport virtual void			transform(const Mat &T) override;
         DllExport virtual Vec3f			getOrigin(void) const override { return m_origin; }
-        DllExport virtual Vec3f			getNormal(const Ray &) const override;
+        DllExport virtual Vec3f			doGetNormal(const Ray &) const override;
 		DllExport virtual Vec2f			getTextureCoords(const Ray &ray) const override;
         DllExport virtual CBoundingBox	getBoundingBox(void) const override { return m_boundingBox; }
 

--- a/modules/core/IPrim.h
+++ b/modules/core/IPrim.h
@@ -35,7 +35,7 @@ namespace rt {
 		 * @retval true If and only if a valid intersection has been found in the interval (epsilon; Ray::t)
 		 * @retval false Otherwise
 		 */
-		DllExport virtual bool				intersect(Ray& ray) const = 0;
+		DllExport virtual bool				intersect(Ray& ray) = 0;
 		/**
 		 * @brief Checks for intersection between ray \b ray and the primitive
 		 * @details This function does not modify argeument \b ray and is used just to check if there is an intersection.
@@ -56,19 +56,6 @@ namespace rt {
 		 */
 		DllExport virtual Vec3f				getOrigin(void) const = 0;
 		/**
-		 * @brief Returns the normal vector of the primitive in the ray - primitive intercection point
-		 * @param ray Ray intersecting the primitive
-		 * @return The normalized normal of the primitive at the ray - primitive intersection point
-		 */
-		DllExport virtual Vec3f				getNormal(const Ray& ray) const = 0;
-		/**
-		* @brief Returns the  normal vector of the primitive in the ray - primitive intercection point
-		* @note In contrast to the @ref getNormal() method, this methods takes into account the possible normal interpolation along the primitive
-		* @param ray Ray intersecting the primitive
-		* @retunrn The normalized normal of the primitive at the ray - primitive intersection point
-		*/
-		DllExport virtual Vec3f				getShadingNormal(const Ray& ray) const { return getNormal(ray); }
-		/**
 		 * @brief Returns the texture coordinates in the ray - primitive intercection point
 		 * @param ray Point at the surface
 		 * @return The texture coordinates
@@ -79,11 +66,6 @@ namespace rt {
 		 * @returns The bounding box, which contain the primitive
 		 */
 		DllExport virtual CBoundingBox		getBoundingBox(void) const = 0;
-//		/**
-//		 * @brief Sets the new shader to the prim
-//		 * @param pShader Pointer to the shader to be applied for the prim
-//		 */
-//		DllExport void						setShader(const ptr_shader_t pShader) { m_pShader = pShader; }
 		/**
 		 * @brief Returns the primitive's shader
 		 * @return The pointer to the primitive's shader
@@ -99,10 +81,35 @@ namespace rt {
 		 * @return The name of the primitive
 		 */
 		DllExport std::string				getName(void) const { return m_name; }
+		/**
+		 * @brief Returns the normal vector of the primitive in the ray - primitive intercection point
+		 * @param ray Ray intersecting the primitive
+		 * @return The normalized normal of the primitive at the ray - primitive intersection point
+		 */
+		DllExport Vec3f 					getNormal(const Ray& ray) const { return m_flipped ? -doGetNormal(ray) : doGetNormal(ray); };
+		/**
+		 * @brief Toggles the normal direction by modifying @ref m_flipped.
+		 */
+		DllExport void 						flipNormal() { m_flipped = !m_flipped; }
+		/**
+		* @brief Returns the  normal vector of the primitive in the ray - primitive intercection point
+		* @note In contrast to the @ref getNormal() method, this methods takes into account the possible normal interpolation along the primitive
+		* @param ray Ray intersecting the primitive
+		* @retunrn The normalized normal of the primitive at the ray - primitive intersection point
+		*/
+		DllExport virtual Vec3f				getShadingNormal(const Ray& ray) const { return getNormal(ray); }
 	
-	
+	protected:
+		/**
+		 * @brief Returns the normal vector of the primitive in the ray - primitive intercection point
+		 * @param ray Ray intersecting the primitive
+		 * @return The normalized normal of the primitive at the ray - primitive intersection point
+		 */
+		DllExport virtual Vec3f				doGetNormal(const Ray& ray) const = 0;
+
 	private:
 		const ptr_shader_t	m_pShader;			///< Pointer to the sahder, see @ref  IShader
 		std::string			m_name;				///< Optional name of the primitive
+		bool				m_flipped;	///< Validates if the normal should be flipped
 	};
 }

--- a/modules/core/PrimDisc.cpp
+++ b/modules/core/PrimDisc.cpp
@@ -3,7 +3,7 @@
 #include "Transform.h"
 
 namespace rt {
-	bool CPrimDisc::intersect(Ray& ray) const
+	bool CPrimDisc::intersect(Ray& ray)
 	{
 		float dist = (m_origin - ray.org).dot(m_normal) / ray.dir.dot(m_normal);
 		if (dist < Epsilon || isinf(dist) || dist > ray.t) return false;

--- a/modules/core/PrimDisc.h
+++ b/modules/core/PrimDisc.h
@@ -29,11 +29,11 @@ namespace rt {
 		{}
 		DllExport virtual ~CPrimDisc(void) = default;
 		
-		DllExport virtual bool				intersect(Ray& ray) const override;
+		DllExport virtual bool				intersect(Ray& ray) override;
 		DllExport virtual bool				if_intersect(const Ray& ray) const override;
 		DllExport virtual void				transform(const Mat& T) override;
 		DllExport virtual Vec3f				getOrigin(void) const override { return m_origin; }
-		DllExport virtual Vec3f				getNormal(const Ray& ray) const override { return m_normal; }
+		DllExport virtual Vec3f				doGetNormal(const Ray& ray) const override { return m_normal; }
 		DllExport virtual Vec2f				getTextureCoords(const Ray& ray) const override;
 		DllExport virtual CBoundingBox		getBoundingBox(void) const override;
 		

--- a/modules/core/PrimDummy.cpp
+++ b/modules/core/PrimDummy.cpp
@@ -2,7 +2,7 @@
 #include <macroses.h>
 
 namespace rt {
-    bool CPrimDummy::intersect(Ray &) const {
+    bool CPrimDummy::intersect(Ray &) {
         RT_ASSERT_MSG(false, "This method should never be called. Aborting...");
     }
 

--- a/modules/core/PrimDummy.h
+++ b/modules/core/PrimDummy.h
@@ -17,11 +17,11 @@ namespace rt {
         {}
         DllExport virtual ~CPrimDummy(void) = default;
 
-        DllExport bool 			intersect(Ray& ray) const override;
+        DllExport bool 			intersect(Ray& ray) override;
         DllExport bool 			if_intersect(const Ray& ray) const override;
         DllExport void 			transform(const Mat& T) override;
         DllExport Vec3f			getOrigin(void) const override;
-		DllExport Vec3f 		getNormal(const Ray&) const override { return m_normal;  }
+		DllExport Vec3f 		doGetNormal(const Ray&) const override { return m_normal;  }
 		DllExport Vec2f			getTextureCoords(const Ray& ray) const override { return m_textureCoord; }
         DllExport CBoundingBox	getBoundingBox(void) const override;
 

--- a/modules/core/PrimPlane.cpp
+++ b/modules/core/PrimPlane.cpp
@@ -3,7 +3,7 @@
 #include "Transform.h"
 
 namespace rt {
-	bool CPrimPlane::intersect(Ray& ray) const
+	bool CPrimPlane::intersect(Ray& ray)
 	{
 		float dist = (m_origin - ray.org).dot(m_normal) / ray.dir.dot(m_normal);
 		if (dist < Epsilon || isinf(dist) || dist > ray.t) return false;

--- a/modules/core/PrimPlane.h
+++ b/modules/core/PrimPlane.h
@@ -29,11 +29,11 @@ namespace rt {
 		}
 		DllExport virtual ~CPrimPlane(void) = default;
 
-		DllExport virtual bool 			intersect(Ray& ray) const override;
+		DllExport virtual bool 			intersect(Ray& ray) override;
 		DllExport virtual bool 			if_intersect(const Ray& ray) const override;
 		DllExport virtual void 			transform(const Mat& T) override;
 		DllExport virtual Vec3f			getOrigin(void) const override { return m_origin; }
-		DllExport virtual Vec3f 		getNormal(const Ray&) const override { return m_normal; }
+		DllExport virtual Vec3f 		doGetNormal(const Ray&) const override { return m_normal; }
 		DllExport virtual Vec2f			getTextureCoords(const Ray& ray) const override;
 		DllExport virtual CBoundingBox	getBoundingBox(void) const override;
 

--- a/modules/core/PrimSphere.cpp
+++ b/modules/core/PrimSphere.cpp
@@ -4,7 +4,7 @@
 #include "macroses.h"
 
 namespace rt {
-	bool CPrimSphere::intersect(Ray& ray) const
+	bool CPrimSphere::intersect(Ray& ray)
 	{
 		double r2 = static_cast<double>(m_radius) * static_cast<double>(m_radius);
 #if 1
@@ -56,7 +56,7 @@ namespace rt {
 	/// @todo Optimize it
 	bool CPrimSphere::if_intersect(const Ray& ray) const
 	{
-		return intersect(lvalue_cast(Ray(ray)));
+        return const_cast<CPrimSphere*>(this)->intersect(lvalue_cast(Ray(ray)));
 	}
 
 	void CPrimSphere::transform(const Mat& T)
@@ -72,7 +72,7 @@ namespace rt {
 		m_radius = static_cast<float>(norm(r));
 	}
 
-	Vec3f CPrimSphere::getNormal(const Ray& ray) const
+	Vec3f CPrimSphere::doGetNormal(const Ray& ray) const
 	{
 		return normalize(ray.hitPoint() - m_origin);
 	}

--- a/modules/core/PrimSphere.h
+++ b/modules/core/PrimSphere.h
@@ -27,11 +27,11 @@ namespace rt {
 		{}
 		DllExport virtual ~CPrimSphere(void) = default;
 
-		DllExport virtual bool 			intersect(Ray& ray) const override;
+		DllExport virtual bool 			intersect(Ray& ray) override;
 		DllExport virtual bool 			if_intersect(const Ray& ray) const override;
 		DllExport virtual void 			transform(const Mat& T) override;
 		DllExport virtual Vec3f			getOrigin(void) const override { return m_origin; }
-		DllExport virtual Vec3f 		getNormal(const Ray& ray) const override;
+		DllExport virtual Vec3f 		doGetNormal(const Ray& ray) const override;
 		DllExport virtual Vec2f			getTextureCoords(const Ray& ray) const override;
 		DllExport virtual CBoundingBox	getBoundingBox(void) const override;
 

--- a/modules/core/PrimTriangle.cpp
+++ b/modules/core/PrimTriangle.cpp
@@ -3,7 +3,7 @@
 #include "Transform.h"
 
 namespace rt {
-	bool CPrimTriangle::intersect(Ray& ray) const
+	bool CPrimTriangle::intersect(Ray& ray)
 	{
 		auto t = MoellerTrumbore(ray);
 		if (t) {
@@ -41,7 +41,7 @@ namespace rt {
 		return 0.33f * (m_a + m_b + m_c);
 	}
 
-	Vec3f CPrimTriangle::getNormal(const Ray& ray) const
+	Vec3f CPrimTriangle::doGetNormal(const Ray& ray) const
 	{
 			return m_normal;
 	}

--- a/modules/core/PrimTriangle.h
+++ b/modules/core/PrimTriangle.h
@@ -44,11 +44,11 @@ namespace rt {
 		{}
 		DllExport virtual ~CPrimTriangle(void) = default;
 		
-		DllExport virtual bool	intersect(Ray& ray) const override;
+		DllExport virtual bool	intersect(Ray& ray) override;
 		DllExport virtual bool	if_intersect(const Ray& ray) const override { return MoellerTrumbore(ray).has_value(); }
 		DllExport virtual void	transform(const Mat& t) override;
 		DllExport virtual Vec3f	getOrigin(void) const override;
-		DllExport virtual Vec3f getNormal(const Ray& ray) const override;
+		DllExport virtual Vec3f doGetNormal(const Ray& ray) const override;
 		DllExport virtual Vec3f getShadingNormal(const Ray& ray) const override;
 		DllExport virtual Vec2f	getTextureCoords(const Ray& ray) const override;
 		DllExport CBoundingBox	getBoundingBox(void) const override;

--- a/modules/core/Ray.h
+++ b/modules/core/Ray.h
@@ -18,7 +18,7 @@ namespace rt {
 		size_t 							counter;											///< Number of re-traces
 		
 		double							t		= std::numeric_limits<double>::infinity();	///< Current/maximum hit distance
-		std::shared_ptr<const IPrim>	hit		= nullptr;									///< Pointer to currently closest primitive
+		std::shared_ptr<IPrim>	hit		= nullptr;									///< Pointer to currently closest primitive
 		float							u		= 0;										///< Barycentric u coordinate
 		float							v		= 0;										///< Barycentric v coordinate
 		


### PR DESCRIPTION
A few issues I encountered that I would like to discuss before proceeding:

1. Adding the normal flipping functionality requires us to make changes to the `hit` member variable in `Ray` and change it from a const to non-cost since this can now be modified inside some intersect method (i.e. inside CCompositeGeometry).

2. We also need to change the intersect method to become `non-const` as we now need the `shared_from_this()` overload that provides a non-const `shared_ptr`. 

3. The issue now is that these changes cause the geometries to change 'globally'. For example, one ray intersection could cause the IPrim (could be an entire sphere) to flip its normal and this causes artifacts for all the future classifications since they're done thanks to the information provided by normals. So an entering ray could be classified as exit or miss.

Therefore, I'm thinking of 2 solutions here:

1. Using a copy constructor to duplicate this information and make sure that these base primitives are not changed globally. However, this raises a larger memory concern since increased resolution can lead to potentially hundreds of thousands of larger primitives (e.g. IPrimTriangle holds a lot of information).

2. Sticking to the approach with these dummy primitives but finding a way of cleaning up their implementation to be more concise.

Would be happy to hear any ideas on how we can overcome this?
Thank you!

Resolves #35 



